### PR TITLE
Add Bed Wars stars to guild members list, add player position on mouse over

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="CommitMessageInspectionProfile">
+    <profile version="1.0">
+      <inspection_tool class="GrazieCommit" enabled="true" level="TYPO" enabled_by_default="true" />
+    </profile>
+  </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
   </component>

--- a/Envoy.blade.php
+++ b/Envoy.blade.php
@@ -28,36 +28,36 @@ build
 @endfinished
 
 @task('optimize')
-cd /var/www/nginx/hypixel-signatures
+cd /var/www/hypixel-signatures
 php artisan optimize
 @endtask
 
 @task('down')
-cd /var/www/nginx/hypixel-signatures
+cd /var/www/hypixel-signatures
 php artisan down
 @endtask
 
 @task('up')
-cd /var/www/nginx/hypixel-signatures
+cd /var/www/hypixel-signatures
 php artisan up
 @endtask
 
 @task('git')
-cd /var/www/nginx/hypixel-signatures
+cd /var/www/hypixel-signatures
 git pull
 @endtask
 
 @task('composer')
-cd /var/www/nginx/hypixel-signatures
+cd /var/www/hypixel-signatures
 composer install
 @endtask
 
 @task('node')
-cd /var/www/nginx/hypixel-signatures
+cd /var/www/hypixel-signatures
 npm install
 @endtask
 
 @task('build')
-cd /var/www/nginx/hypixel-signatures
+cd /var/www/hypixel-signatures
 npm run prod
 @endtask

--- a/app/Http/Controllers/Guild/BedWarsController.php
+++ b/app/Http/Controllers/Guild/BedWarsController.php
@@ -135,7 +135,12 @@ namespace App\Http\Controllers\Guild;
                     $finalKd = 'N/A';
                 }
 
+                $achievements = $player->getArray('achievements');
+
+                $level = $achievements['bedwars_level'] ?? 0;
+
                 return [
+                    'level'           => $level,
                     'wins'            => $wins,
                     'kills'           => $totalKills,
                     'deaths'          => $totalDeaths,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,7 @@ devDependencies:
   laravel-mix: 5.0.4_vue-template-compiler@2.6.11
   laravel-mix-bundle-analyzer: 1.0.5_laravel-mix@5.0.4
   laravel-mix-purgecss: 5.0.0_laravel-mix@5.0.4
-  lodash: 4.17.15
+  lodash: 4.17.19
   moment-locales-webpack-plugin: 1.2.0_moment@2.27.0
   resolve-url-loader: 2.3.2
   sass: 1.26.9
@@ -4837,6 +4837,10 @@ packages:
     dev: true
     resolution:
       integrity: sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+  /lodash/4.17.19:
+    dev: true
+    resolution:
+      integrity: sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
   /loglevel/1.6.8:
     dev: true
     engines:
@@ -5161,6 +5165,7 @@ packages:
     resolution:
       integrity: sha512-QAi5v0OlPUP7GXviKMtxnpBAo8WmTHrUNN7iciAhNOEAd9evCOvuN0g1N7ThIg3q11GLCkjY1zQ2saRcf/43nQ==
   /moment/2.27.0:
+    dev: false
     resolution:
       integrity: sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ==
   /move-concurrently/1.0.1:
@@ -8301,7 +8306,7 @@ specifiers:
   laravel-mix: ^5
   laravel-mix-bundle-analyzer: ^1.0.5
   laravel-mix-purgecss: ^5.0.0
-  lodash: ^4.17.13
+  lodash: ^4.17.19
   moment: ^2.27.0
   moment-locales-webpack-plugin: ^1.2.0
   resolve-url-loader: ^2.3.1

--- a/resources/js/friends.js
+++ b/resources/js/friends.js
@@ -63,7 +63,7 @@ new Vue({
                 this.getFriends().finally(() => {
                     setTimeout(() => {
                         this.getFriendsInterval();
-                    }, this.meta.loaded === previousCount ? 7500 : 750);
+                    }, this.meta.loaded === previousCount ? 2500 : 750);
                 });
             }
         },

--- a/resources/js/guild.js
+++ b/resources/js/guild.js
@@ -68,7 +68,7 @@ new Vue({
                 this.getMembers().finally(() => {
                     setTimeout(() => {
                         this.getMembersInterval();
-                    }, this.meta.loaded === previousCount ? 7500 : 750);
+                    }, this.meta.loaded === previousCount ? 2500 : 750);
                 });
             }
         },

--- a/resources/js/guild/BedWarsTable.vue
+++ b/resources/js/guild/BedWarsTable.vue
@@ -49,6 +49,7 @@
                 </tr>
                 <tr>
                     <!--Total-->
+                    <sortable-header name="level">Stars</sortable-header>
                     <sortable-header name="wins">Wins</sortable-header>
                     <sortable-header name="kills">Kills</sortable-header>
                     <sortable-header name="kd">K/D</sortable-header>
@@ -73,6 +74,9 @@
                     <span class="formatted-name" v-html="data.item.formatted_name"></span>
                 </td>
                 <!--Total-->
+                <td>
+                    {{ data.item.level }}
+                </td>
                 <td>
                     {{ data.item.wins }}
                 </td>
@@ -107,6 +111,7 @@
                 <tr>
                     <th>Guild Average</th>
                     <!--Total-->
+                    <calculated-cell name="level"></calculated-cell>
                     <calculated-cell name="wins"></calculated-cell>
                     <calculated-cell name="kills"></calculated-cell>
                     <calculated-cell :precision="2" name="kd"></calculated-cell>
@@ -122,6 +127,7 @@
                 <tr>
                     <th>Guild Total</th>
                     <!--Total-->
+                    <calculated-cell name="level" type="total"></calculated-cell>
                     <calculated-cell name="wins" type="total"></calculated-cell>
                     <calculated-cell name="kills" type="total"></calculated-cell>
                     <calculated-cell :precision="2" deaths="deaths" kills="kills" type="total_kd"></calculated-cell>

--- a/resources/lang/en/guild.php
+++ b/resources/lang/en/guild.php
@@ -82,6 +82,8 @@
             'yes'               => 'Yes',
             'no'                => 'No',
             'listed'            => 'Publicly listed',
+
+            'click_to_sort' => 'You can click the table headers to sort the guild members by specific statistics. If you would like to know the exact position a player is on for a guild leaderboard, hover over the username in order to see their relative position for the currently sorted statistic!'
         ],
 
         'members' => [

--- a/resources/lang/nl/guild.php
+++ b/resources/lang/nl/guild.php
@@ -58,5 +58,7 @@
                 'default_description' => ':name is een guild op de Hypixel Minecraft-server',
                 'description'         => " - Bekijk de leden van :name's, hun statistieken en zelfs minigame-statistieken voor SkyWars, Bed Wars en meer spellen voor heel de guild op :site."
             ],
+
+            'click_to_sort' => 'Je kan op de kolommen klikken om de leden te sorteren op basis van bepaalde statistieken. Als je de precieze positie van een speler op het getoonde guild-scorebord wil zien, beweeg dan je cursor over een gebruikersnaam om de relatieve positie voor de huidige sortering te zien!'
         ]
     ];

--- a/resources/sass/_guild.scss
+++ b/resources/sass/_guild.scss
@@ -106,6 +106,7 @@
     border-spacing: 0;
     border-collapse: collapse;
     border-radius: $border-radius;
+    counter-reset: index;
 
     &.compact {
       td, th {
@@ -144,6 +145,23 @@
       img {
         display: inline-block;
         vertical-align: middle;
+      }
+
+      .formatted-name {
+        counter-increment: index;
+
+        &::after {
+          content: " #" counter(index);
+          display: none;
+        }
+      }
+
+      &:hover, &:focus {
+        .formatted-name {
+          &::after {
+            display: revert;
+          }
+        }
       }
     }
 

--- a/resources/views/guild/members.twig
+++ b/resources/views/guild/members.twig
@@ -6,7 +6,10 @@
 
 {% block guild_content %}
     {% block table_title %}
-        <h1>{{ trans('guild.members.title', { name: guild.name, link: route('guild.info', [guild.name]) })|raw }}</h1>{% endblock %}
+        <h1>{{ trans('guild.members.title', { name: guild.name, link: route('guild.info', [guild.name]) })|raw }}</h1>
+    {% endblock %}
+
+    <p>{{ trans('guild.info.click_to_sort') }}</p>
 
     <div id="guild-members-app">
         <div class="progress-info" v-if="meta.loaded < meta.total_members" v-cloak>


### PR DESCRIPTION
This partially resolves #42 as it adds Bed Wars stars to the Bed Wars guild statistics. It also shows the position of a player on the guild leaderboard on mouse over.